### PR TITLE
Add IOC correlation report

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,15 @@ Para testes locais sem acessar a API, informe `ABUSE_MOCK_FILE` apontando para u
 ## Debug
 
 Os logs sao gravados em `logs/` e tambem exibidos coloridos no terminal utilizando `rich`. Para aumentar a verbosidade, altere o nivel em `setup_logging()` para `DEBUG`.
+
+## Relatórios e correlação
+
+Para resumir os IOCs coletados em um determinado dia e verificar valores
+repetidos entre os feeds, utilize o módulo `ioc_collector.report`:
+
+```bash
+python -m ioc_collector.report --date AAAA-MM-DD --output relatorio.json
+```
+
+O arquivo gerado contém estatísticas por fonte e tipo de IOC, além dos
+indicadores que apareceram em mais de um coletor.

--- a/ioc_collector/report.py
+++ b/ioc_collector/report.py
@@ -1,0 +1,59 @@
+import argparse
+import datetime
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ALERTS_FILE = Path(__file__).resolve().parent / "alerts.json"
+
+
+def generate_report(date: str) -> dict:
+    if not ALERTS_FILE.exists():
+        raise FileNotFoundError("alerts.json não encontrado")
+    with ALERTS_FILE.open("r", encoding="utf-8") as fh:
+        alerts = json.load(fh)
+    daily = [a for a in alerts if a.get("date") == date]
+    total = len(daily)
+
+    by_source = Counter(a.get("source") for a in daily)
+    by_type = Counter(a.get("ioc_type") for a in daily)
+
+    occurrences = defaultdict(list)
+    for a in daily:
+        occurrences[a.get("ioc_value")].append(a.get("source"))
+
+    duplicates = {
+        val: list(set(srcs)) for val, srcs in occurrences.items() if len(set(srcs)) > 1
+    }
+
+    top_values = Counter([a.get("ioc_value") for a in daily]).most_common(10)
+
+    return {
+        "date": date,
+        "total_iocs": total,
+        "by_source": dict(by_source),
+        "by_type": dict(by_type),
+        "duplicates": duplicates,
+        "top_values": top_values,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Gera relatório de IOCs")
+    parser.add_argument(
+        "--date",
+        default=datetime.date.today().isoformat(),
+        help="Data dos IOCs (YYYY-MM-DD)",
+    )
+    parser.add_argument("--output", help="Salvar relatório em arquivo JSON")
+    args = parser.parse_args()
+
+    report = generate_report(args.date)
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    if args.output:
+        out = Path(args.output)
+        out.write_text(json.dumps(report, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ioc_collector.report` module to generate statistics and deduplicate IOCs
- document how to run the report in README

## Testing
- `python -m ioc_collector.main`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853242f7cc48320b58eda548545c7af