### PR TITLE
Update AGENTS with docs status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ The initial sprint added a reporting module with several options.
 - Friendly message when no data is found.
 - `Report` dataclass for consistent output.
 - README examples for generating reports.
+- Documentation covers the `--value` and `--sort` options.
 
 ### Pending
  - Dashboard/API integrations and alert notifications.
@@ -30,6 +31,5 @@ The initial sprint added a reporting module with several options.
 ### Next steps
 - Add asynchronous collectors for performance.
 - Provide dashboard visualization for reports.
-- Improve documentation about the new `--value` and `--sort` options.
 
 To update these instructions send a pull request editing this file.


### PR DESCRIPTION
## Summary
- document that `--value` and `--sort` CLI options are already covered in README
- remove completed TODO for improving docs

## Testing
- `ABUSE_MOCK_FILE=data/mock/abuse_sample.json python -m ioc_collector.main --log-level INFO`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685335bbb9e88320b4d99eac9c97d5bb