### PR TITLE
Add IOC correlation report

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ chamadas/dia). Ao ultrapassar esse valor o serviço retorna HTTP 429.
    python -m ioc_collector.main
    ```
 
+   Após a coleta um relatório consolidado é salvo automaticamente nos arquivos
+   `ioc_correlation_report.csv` e `ioc_correlation_report.xlsx` contendo a
+   correlação dos IOCs entre os feeds.
+
 5. Para exibir os IPs mais reportados em determinada data:
 
    ```bash
@@ -100,8 +104,9 @@ Os logs sao gravados em `logs/` e tambem exibidos coloridos no terminal utilizan
 
 ## Relatórios e correlação
 
-Para resumir os IOCs coletados em um determinado dia e verificar valores
-repetidos entre os feeds, utilize o módulo `ioc_collector.report`:
+Após cada execução do coletor principal é gerado automaticamente um relatório
+com a correlação dos IOCs encontrados nas diferentes fontes. Para consultas
+manuais ou filtros adicionais continue utilizando o módulo `ioc_collector.report`:
 
 ```bash
 python -m ioc_collector.report --date AAAA-MM-DD --output-json relatorio.json

--- a/ioc_collector/main.py
+++ b/ioc_collector/main.py
@@ -18,6 +18,7 @@ from ioc_collector.utils.utils import (
     load_config,
     save_daily_iocs,
 )
+from ioc_collector.report import save_correlation_reports
 from ioc_collector.alerts_manager import (
     update_alerts,
     check_duplicates,
@@ -114,6 +115,16 @@ def run_collectors(config: dict, selected: list | None = None) -> None:
     dups = check_duplicates(ALERTS_FILE)
     if dups:
         logging.warning("Valores duplicados em alerts.json: %s", ", ".join(dups))
+
+    try:
+        print("Gerando relatório consolidado...")
+        save_correlation_reports(
+            all_iocs,
+            Path("ioc_correlation_report.csv"),
+            Path("ioc_correlation_report.xlsx"),
+        )
+    except Exception:
+        logging.exception("Erro ao gerar relatório consolidado")
 
     if config.get("GENERATE_REQUIREMENTS", True):
         generate_requirements(Path(__file__).with_name("requirements.txt"))

--- a/ioc_collector/requirements.txt
+++ b/ioc_collector/requirements.txt
@@ -47,3 +47,4 @@ urllib3==2.5.0
 uvicorn==0.27.0.post1
 xlwt==1.3.0
 yarl==1.20.1
+pandas==2.2.2

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from ioc_collector.report import build_correlation_dataframe
+
+
+def test_build_correlation_dataframe():
+    iocs = [
+        {"ioc_value": "1.1.1.1", "ioc_type": "IP", "source": "AbuseIPDB"},
+        {"ioc_value": "1.1.1.1", "ioc_type": "IP", "source": "OTX"},
+        {"ioc_value": "evil.com", "ioc_type": "URL", "source": "URLHaus"},
+    ]
+    df = build_correlation_dataframe(iocs)
+    row = df[df["ioc_value"] == "1.1.1.1"].iloc[0]
+    assert row["source_count"] == 2
+    assert set(row["sources"]) == {"AbuseIPDB", "OTX"}
+    assert row["risk_score"] == 20


### PR DESCRIPTION
## Summary
- generate IOC correlation report with pandas
- save correlation report automatically from main
- mention new auto report in README
- add pandas requirement
- test correlation dataframe

## Testing
- `python -m ioc_collector.main --collectors abuseipdb --log-level INFO`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854291dbb148320a0af3dbbe7d3f35a