### PR TITLE
Add detailed Excel report per IOC type

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ chamadas/dia). Ao ultrapassar esse valor o serviço retorna HTTP 429.
    python -m ioc_collector.main
    ```
 
+   Após a coleta um relatório consolidado é salvo automaticamente nos arquivos
+   `ioc_correlation_report.csv` e `ioc_correlation_report.xlsx` contendo a
+   correlação dos IOCs entre os feeds. O arquivo Excel possui abas separadas
+   (IPs, URLs, Hashes e Domínios) com detalhes adicionais como país, ASN e
+   recomendações de mitigação.
+
 5. Para exibir os IPs mais reportados em determinada data:
 
    ```bash
@@ -100,8 +106,10 @@ Os logs sao gravados em `logs/` e tambem exibidos coloridos no terminal utilizan
 
 ## Relatórios e correlação
 
-Para resumir os IOCs coletados em um determinado dia e verificar valores
-repetidos entre os feeds, utilize o módulo `ioc_collector.report`:
+Após cada execução do coletor principal é gerado automaticamente um relatório
+com a correlação dos IOCs encontrados nas diferentes fontes. O Excel gerado já
+contém abas específicas para IPs, URLs, hashes e domínios. Para consultas
+manuais ou filtros adicionais continue utilizando o módulo `ioc_collector.report`:
 
 ```bash
 python -m ioc_collector.report --date AAAA-MM-DD --output-json relatorio.json

--- a/ioc_collector/main.py
+++ b/ioc_collector/main.py
@@ -18,6 +18,7 @@ from ioc_collector.utils.utils import (
     load_config,
     save_daily_iocs,
 )
+from ioc_collector.report import save_correlation_reports
 from ioc_collector.alerts_manager import (
     update_alerts,
     check_duplicates,
@@ -114,6 +115,16 @@ def run_collectors(config: dict, selected: list | None = None) -> None:
     dups = check_duplicates(ALERTS_FILE)
     if dups:
         logging.warning("Valores duplicados em alerts.json: %s", ", ".join(dups))
+
+    try:
+        print("Gerando relatório consolidado...")
+        save_correlation_reports(
+            all_iocs,
+            Path("ioc_correlation_report.csv"),
+            Path("ioc_correlation_report.xlsx"),
+        )
+    except Exception:
+        logging.exception("Erro ao gerar relatório consolidado")
 
     if config.get("GENERATE_REQUIREMENTS", True):
         generate_requirements(Path(__file__).with_name("requirements.txt"))

--- a/ioc_collector/report.py
+++ b/ioc_collector/report.py
@@ -16,6 +16,8 @@ from fpdf import FPDF
 from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
 import xlwt
+import pandas as pd
+import requests
 
 from rich.console import Console
 from rich.table import Table
@@ -50,8 +52,133 @@ def _filter_alerts(
             continue
         if value and a.get("ioc_value") != value:
             continue
-        result.append(a)
+    result.append(a)
     return result
+
+
+def build_correlation_dataframe(iocs: List[Dict[str, any]]):
+    """Return DataFrame with correlation columns based on IOC value."""
+    df = pd.DataFrame(iocs)
+    if df.empty:
+        return df
+
+    grouped = df.groupby("ioc_value")
+    sources = grouped["source"].apply(lambda x: sorted(set(x))).reset_index(name="sources")
+    unique = grouped.first().reset_index()
+    merged = unique.merge(sources, on="ioc_value")
+    merged["source_count"] = merged["sources"].apply(len)
+    merged["risk_score"] = merged["source_count"] * 10
+    return merged.drop(columns=["source"], errors="ignore")
+
+
+_ip_cache: Dict[str, Dict[str, str]] = {}
+
+
+def _fetch_ip_info(ip: str) -> Dict[str, str]:
+    """Return country and ASN information for an IP using ip-api.com."""
+    if ip in _ip_cache:
+        return _ip_cache[ip]
+
+    try:
+        resp = requests.get(f"http://ip-api.com/json/{ip}", timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        logging.exception("Falha ao consultar ip-api para %s", ip)
+        data = {}
+
+    info = {"country": data.get("country", ""), "asn": data.get("as", "")}
+    _ip_cache[ip] = info
+    return info
+
+
+def _mitigation_ip(count: int) -> str:
+    if count >= 3:
+        return "Bloqueio imediato"
+    if count == 2:
+        return "Monitorar e bloquear se necessário"
+    return "Monitorar"
+
+
+def _mitigation_url(_: int) -> str:
+    return "Bloquear URL no proxy/firewall"
+
+
+def _mitigation_hash(_: int) -> str:
+    return "Isolar arquivo e analisar em sandbox"
+
+
+def _mitigation_domain(_: int) -> str:
+    return "Bloquear domínio e monitorar DNS"
+
+
+def _save_detailed_excel(df: pd.DataFrame, path: Path) -> None:
+    """Create Excel with separate sheets by IOC type."""
+    logging.info("Salvando relatorio detalhado em %s", path)
+    with pd.ExcelWriter(path, engine="openpyxl") as writer:
+        # IPs
+        ip_df = df[df["ioc_type"].str.upper() == "IP"].copy()
+        if not ip_df.empty:
+            logging.info("Adicionando aba de IPs (%s entradas)", len(ip_df))
+            ip_df["Fontes"] = ip_df["sources"].apply(lambda s: ", ".join(s))
+            ip_df["País"] = ip_df["ioc_value"].apply(lambda ip: _fetch_ip_info(ip)["country"])
+            ip_df["ASN"] = ip_df["ioc_value"].apply(lambda ip: _fetch_ip_info(ip)["asn"])
+            ip_df["Mitigação recomendada"] = ip_df["source_count"].apply(_mitigation_ip)
+            cols = ["ioc_value", "Fontes", "País", "ASN", "source_count", "risk_score", "Mitigação recomendada"]
+            ip_df = ip_df[cols]
+            ip_df.columns = ["IP", "Fontes", "País", "ASN", "Quantidade de Fontes", "Score de Risco", "Mitigação recomendada"]
+            ip_df.to_excel(writer, sheet_name="IPs", index=False)
+
+        # URLs
+        url_df = df[df["ioc_type"].str.upper() == "URL"].copy()
+        if not url_df.empty:
+            logging.info("Adicionando aba de URLs (%s entradas)", len(url_df))
+            url_df["Fontes"] = url_df["sources"].apply(lambda s: ", ".join(s))
+            url_df["Descrição da ameaça"] = url_df.get("description", "")
+            url_df["Mitigação recomendada"] = url_df["source_count"].apply(_mitigation_url)
+            cols = ["ioc_value", "Fontes", "Descrição da ameaça", "source_count", "risk_score", "Mitigação recomendada"]
+            url_df = url_df[cols]
+            url_df.columns = ["URL", "Fontes", "Descrição da ameaça", "Quantidade de Fontes", "Score de Risco", "Mitigação recomendada"]
+            url_df.to_excel(writer, sheet_name="URLs", index=False)
+
+        # Hashes
+        hash_df = df[df["ioc_type"].str.contains("HASH", case=False, na=False) | df["ioc_type"].str.contains("MD5", case=False, na=False) | df["ioc_type"].str.contains("SHA", case=False, na=False)].copy()
+        if not hash_df.empty:
+            logging.info("Adicionando aba de Hashes (%s entradas)", len(hash_df))
+            hash_df["Fontes"] = hash_df["sources"].apply(lambda s: ", ".join(s))
+            hash_df["Mitigação recomendada"] = hash_df["source_count"].apply(_mitigation_hash)
+            cols = ["ioc_value", "ioc_type", "Fontes", "source_count", "risk_score", "Mitigação recomendada"]
+            hash_df = hash_df[cols]
+            hash_df.columns = ["Hash", "Tipo", "Fontes", "Quantidade de Fontes", "Score de Risco", "Mitigação recomendada"]
+            hash_df.to_excel(writer, sheet_name="Hashes", index=False)
+
+        # Domains
+        dom_df = df[df["ioc_type"].str.upper() == "DOMAIN"].copy()
+        if not dom_df.empty:
+            logging.info("Adicionando aba de Domínios (%s entradas)", len(dom_df))
+            dom_df["Fontes"] = dom_df["sources"].apply(lambda s: ", ".join(s))
+            dom_df["Categoria da ameaça"] = dom_df.get("description", "")
+            dom_df["Mitigação recomendada"] = dom_df["source_count"].apply(_mitigation_domain)
+            cols = ["ioc_value", "Fontes", "Categoria da ameaça", "source_count", "risk_score", "Mitigação recomendada"]
+            dom_df = dom_df[cols]
+            dom_df.columns = ["Domínio", "Fontes", "Categoria da ameaça", "Quantidade de Fontes", "Score de Risco", "Mitigação recomendada"]
+            dom_df.to_excel(writer, sheet_name="Domínios", index=False)
+
+
+
+def save_correlation_reports(iocs: List[Dict[str, any]], csv_path: Path, xlsx_path: Path) -> None:
+    """Save correlation report to CSV and Excel."""
+    df = build_correlation_dataframe(iocs)
+    if df.empty:
+        logging.info("Nenhum dado para o relatorio de correlacao")
+        return
+    df.to_csv(csv_path, index=False)
+    _save_detailed_excel(df, xlsx_path)
+    logging.info(
+        "Relatorio de correlacao salvo em %s e %s",
+        csv_path.resolve(),
+        xlsx_path.resolve(),
+    )
 
 
 def generate_report(

--- a/ioc_collector/requirements.txt
+++ b/ioc_collector/requirements.txt
@@ -47,3 +47,4 @@ urllib3==2.5.0
 uvicorn==0.27.0.post1
 xlwt==1.3.0
 yarl==1.20.1
+pandas==2.2.2

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,0 +1,45 @@
+from ioc_collector.report import build_correlation_dataframe, save_correlation_reports
+import requests
+
+
+def test_build_correlation_dataframe():
+    iocs = [
+        {"ioc_value": "1.1.1.1", "ioc_type": "IP", "source": "AbuseIPDB"},
+        {"ioc_value": "1.1.1.1", "ioc_type": "IP", "source": "OTX"},
+        {"ioc_value": "evil.com", "ioc_type": "URL", "source": "URLHaus"},
+    ]
+    df = build_correlation_dataframe(iocs)
+    row = df[df["ioc_value"] == "1.1.1.1"].iloc[0]
+    assert row["source_count"] == 2
+    assert set(row["sources"]) == {"AbuseIPDB", "OTX"}
+    assert row["risk_score"] == 20
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_save_correlation_reports(tmp_path, monkeypatch):
+    iocs = [
+        {"ioc_value": "1.1.1.1", "ioc_type": "IP", "source": "AbuseIPDB"},
+        {"ioc_value": "hashval", "ioc_type": "SHA256", "source": "OTX"},
+        {"ioc_value": "example.com", "ioc_type": "DOMAIN", "source": "OTX"},
+        {"ioc_value": "http://bad.com", "ioc_type": "URL", "source": "URLHaus"},
+    ]
+
+    def mock_get(url, timeout=10):
+        return DummyResp({"country": "US", "as": "AS13335"})
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    csv_path = tmp_path / "out.csv"
+    xlsx_path = tmp_path / "out.xlsx"
+    save_correlation_reports(iocs, csv_path, xlsx_path)
+    assert csv_path.exists()
+    assert xlsx_path.exists()


### PR DESCRIPTION
## Summary
- split correlation Excel report into sheets for IPs, URLs, hashes and domains
- fetch country and ASN via ip-api.com for IP sheet
- add mitigation messages according to IOC category
- document new Excel details in README
- test new save_correlation_reports function

## Testing
- `python -m ioc_collector.main --collectors abuseipdb --log-level INFO`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854291dbb148320a0af3dbbe7d3f35a